### PR TITLE
enable metric recording api

### DIFF
--- a/.dist/deb/Containerfile
+++ b/.dist/deb/Containerfile
@@ -4,7 +4,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 COPY rootfs /
 
 RUN apt-get update
-RUN apt-get -y install software-properties-common build-essential
+RUN apt-get -y install software-properties-common build-essential ca-certificates
 RUN add-apt-repository -n ppa:longsleep/golang-backports
 RUN add-apt-repository -n ppa:egdaemon/eg
 

--- a/.dist/deb/rootfs/etc/containers/registries.conf.d/eg.shortnames.conf
+++ b/.dist/deb/rootfs/etc/containers/registries.conf.d/eg.shortnames.conf
@@ -1,0 +1,2 @@
+[aliases]
+  "archlinux" = "docker.io/library/archlinux"

--- a/.eg/debian/debian.go
+++ b/.eg/debian/debian.go
@@ -6,7 +6,6 @@ import (
 	"eg/ci/maintainer"
 	"encoding/binary"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/egdaemon/eg/runtime/wasi/eg"
@@ -49,11 +48,6 @@ func build(ctx context.Context, _ eg.Op) error {
 
 func Builder(name string, distro string) eg.ContainerRunner {
 	c := eggit.EnvCommit()
-
-	// ensure directory is available.
-	if err := os.MkdirAll(".eg/.cache/.dist", 0777); err != nil {
-		panic(err)
-	}
 
 	return eg.Container(name).
 		OptionEnv("VCS_REVISION", c.Hash.String()).

--- a/.eg/debian/debian.go
+++ b/.eg/debian/debian.go
@@ -6,6 +6,7 @@ import (
 	"eg/ci/maintainer"
 	"encoding/binary"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/egdaemon/eg/runtime/wasi/eg"
@@ -48,6 +49,11 @@ func build(ctx context.Context, _ eg.Op) error {
 
 func Builder(name string, distro string) eg.ContainerRunner {
 	c := eggit.EnvCommit()
+
+	// ensure directory is available.
+	if err := os.MkdirAll(".eg/.cache/.dist", 0777); err != nil {
+		panic(err)
+	}
 
 	return eg.Container(name).
 		OptionEnv("VCS_REVISION", c.Hash.String()).

--- a/.eg/main.go
+++ b/.eg/main.go
@@ -28,6 +28,15 @@ func Debug(ctx context.Context, op eg.Op) error {
 	)
 }
 
+func Prepare(ctx context.Context, op eg.Op) error {
+	return shell.Run(
+		ctx,
+		shell.Newf("pwd"),
+		// shell.Newf("mkdir -p %s", egenv.CacheDirectory(".dist")),
+		shell.New("mkdir -p .eg/.cache/.dist"),
+	)
+}
+
 // main defines the setup for the CI process. here is where you define all
 // of the environments and tasks you wish to run.
 func main() {
@@ -38,10 +47,15 @@ func main() {
 		log.Println("shell output", s)
 	}
 
+	log.Println("debug initiated")
+	defer log.Println("debug completed")
+	env.Debug(os.Environ()...)
+
 	err := eg.Perform(
 		ctx,
-		// Debug,
+		Debug,
 		eggit.AutoClone,
+		Prepare,
 		eg.Parallel(
 			eg.Build(eg.Container(debian.ContainerName).BuildFromFile(".dist/deb/Containerfile")),
 			eg.Build(eg.Container(archlinux.ContainerName).BuildFromFile(".dist/archlinux/Containerfile")),

--- a/.eg/tests/metrics/main.go
+++ b/.eg/tests/metrics/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"log"
+	"math/rand"
+	"time"
+
+	"github.com/egdaemon/eg/runtime/wasi/egmetrics"
+)
+
+type MetricCPU struct {
+	Load float32
+}
+
+func automcpu() MetricCPU {
+	return MetricCPU{
+		Load: rand.Float32(),
+	}
+}
+
+// main defines the setup for the CI process. here is where you define all
+// of the environments and tasks you wish to run.
+func main() {
+	ctx, done := context.WithTimeout(context.Background(), time.Hour)
+	defer done()
+
+	if err := egmetrics.Record(ctx, "cpu", automcpu()); err != nil {
+		log.Fatalln(err)
+	}
+}

--- a/.proto/eg.interp.events.proto
+++ b/.proto/eg.interp.events.proto
@@ -29,15 +29,23 @@ message Task {
   int64 deadline = 5; // unix timestamp.
 }
 
+// metric event contains a json set of fields
+message Metric {
+  string name = 1;
+  reserved 2 to 999;
+  bytes fieldsJSON = 1000;
+}
+
 // Represents every message recorded when executing a job
 message Message {
-  string id = 1;
-  int64 ts = 2; // unix timestamp.
+  string id = 1; // uuid v7
+  int64 ts = 2;  // unix timestamp.
 
   oneof Event {
     LogHeader preamble = 100;
     Heartbeat heartbeat = 101;
     Task task = 102;
+    Metric metric = 103;
   }
 }
 

--- a/interp/analyse.go
+++ b/interp/analyse.go
@@ -12,6 +12,7 @@ import (
 	"github.com/egdaemon/eg/interp/runtime/wasi/ffiexec"
 	"github.com/egdaemon/eg/interp/runtime/wasi/ffigit"
 	"github.com/egdaemon/eg/interp/runtime/wasi/ffigraph"
+	"github.com/egdaemon/eg/interp/runtime/wasi/ffimetric"
 	"github.com/egdaemon/eg/runners"
 	"github.com/tetratelabs/wazero"
 )
@@ -102,7 +103,9 @@ func Analyse(ctx context.Context, g ffigraph.Eventer, runid, dir string, module 
 		).Export("github.com/egdaemon/eg/runtime/wasi/runtime/ffigit.Clone").
 			NewFunctionBuilder().WithFunc(
 			ffigit.CloneV2(r.root),
-		).Export("github.com/egdaemon/eg/runtime/wasi/runtime/ffigit.CloneV2")
+		).Export("github.com/egdaemon/eg/runtime/wasi/runtime/ffigit.CloneV2").
+			NewFunctionBuilder().WithFunc(ffimetric.Metric).
+			Export("github.com/egdaemon/eg/runtime/wasi/runtime/metrics.Record")
 	}
 
 	if err = r.perform(ctx, runid, module, runtimeenv); err != nil {

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -24,6 +24,7 @@ import (
 	"github.com/egdaemon/eg/interp/runtime/wasi/ffiexec"
 	"github.com/egdaemon/eg/interp/runtime/wasi/ffigit"
 	"github.com/egdaemon/eg/interp/runtime/wasi/ffigraph"
+	"github.com/egdaemon/eg/interp/runtime/wasi/ffimetric"
 	"github.com/egdaemon/eg/runners"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
@@ -140,7 +141,10 @@ func Remote(ctx context.Context, runid string, g ffigraph.Eventer, svc grpc.Clie
 		).Export("github.com/egdaemon/eg/runtime/wasi/runtime/ffigit.Clone").
 			NewFunctionBuilder().WithFunc(
 			ffigit.CloneV2(r.root),
-		).Export("github.com/egdaemon/eg/runtime/wasi/runtime/ffigit.CloneV2")
+		).Export("github.com/egdaemon/eg/runtime/wasi/runtime/ffigit.CloneV2").
+			NewFunctionBuilder().WithFunc(
+			ffimetric.Metric,
+		).Export("github.com/egdaemon/eg/runtime/wasi/runtime/metrics.Record")
 	}
 
 	return r.perform(ctx, runid, module, runtimeenv)

--- a/interp/runtime/wasi/ffimetric/ffimetric.go
+++ b/interp/runtime/wasi/ffimetric/ffimetric.go
@@ -1,0 +1,38 @@
+package ffimetric
+
+import (
+	"context"
+	"log"
+
+	"github.com/egdaemon/eg/internal/errorsx"
+	"github.com/egdaemon/eg/interp/runtime/wasi/ffi"
+	"github.com/tetratelabs/wazero/api"
+)
+
+func Metric(
+	ctx context.Context,
+	m api.Module,
+	deadline int64, // context.Context
+	nameoffset uint32, namelen uint32, // string
+	jsonoffset uint32, jsonlen uint32, // []byte
+) uint32 {
+	var (
+		err    error
+		name   string
+		fields []byte
+	)
+
+	if name, err = ffi.ReadString(m.Memory(), nameoffset, namelen); err != nil {
+		log.Println(errorsx.Wrap(err, "unable to read name argument"))
+		return 1
+	}
+
+	if fields, err = ffi.ReadBytes(m.Memory(), jsonoffset, jsonlen); err != nil {
+		log.Println(errorsx.Wrap(err, "unable to read fields argument"))
+		return 1
+	}
+
+	log.Printf("metric event received '%s' '%s'\n", name, string(fields))
+
+	return 0
+}

--- a/runners/daemon.go
+++ b/runners/daemon.go
@@ -95,6 +95,12 @@ func AgentOptionMounts(desc ...string) AgentOption {
 	}
 }
 
+func AgentOptionEnv(key, value string) AgentOption {
+	return func(a *Agent) {
+		a.environ = append(a.environ, "--env", key, value)
+	}
+}
+
 func AgentOptionEnvKeys(keys ...string) AgentOption {
 	vs := []string{}
 	for _, k := range keys {

--- a/runners/queue.go
+++ b/runners/queue.go
@@ -376,6 +376,7 @@ func beginwork(ctx context.Context, md metadata, dir string) state {
 		aopts,
 		AgentOptionEGBin(errorsx.Zero(exec.LookPath(os.Args[0]))),
 		AgentOptionEnviron(environpath),
+		// AgentOptionEnv("EG_CACHE_DIRECTORY", filepath.Join(ws.Root, ws.ModuleDir, ws.CacheDir)),
 	)
 
 	m := NewManager(

--- a/runtime/wasi/egmetrics/egmetrics.go
+++ b/runtime/wasi/egmetrics/egmetrics.go
@@ -1,0 +1,22 @@
+package egmetrics
+
+import (
+	"context"
+
+	"github.com/egdaemon/eg/runtime/wasi/internal/ffimetric"
+)
+
+// Records a metric payload for the given name. the name
+// field is an opaque string identifying the metric.
+// the payload must be consistent with field name -> types.
+// the prefix 'eg.' is reserved for system use.
+// i.e.) ✓ Record(ctx, "example.metric.1", m)
+// i.e.) x Record(ctx, "eg.example.metric.1", m)
+// metrics will be encoded as follows:
+//   - every event will be given a uuid v7 id.
+//   - every event will be given a timestamp.
+//   - name will be recorded as its literal value and as a hashed uuid.
+//   - timestamps must be encoded as ISO8601.
+func Record(ctx context.Context, name string, m any) error {
+	return ffimetric.Record(ctx, name, m)
+}

--- a/runtime/wasi/internal/ffimetric/ffigraph.unimplemented.go
+++ b/runtime/wasi/internal/ffimetric/ffigraph.unimplemented.go
@@ -1,0 +1,17 @@
+//go:build !wasm
+
+package ffimetric
+
+import (
+	"unsafe"
+
+	"github.com/egdaemon/eg/interp/runtime/wasi/ffierrors"
+)
+
+func record(
+	deadline int64, // context.Context
+	nameptr unsafe.Pointer, namelen uint32, // metric name
+	payload unsafe.Pointer, payloadlen uint32, // json payload
+) uint32 {
+	return ffierrors.ErrNotImplemented
+}

--- a/runtime/wasi/internal/ffimetric/ffigraph.wasi.go
+++ b/runtime/wasi/internal/ffimetric/ffigraph.wasi.go
@@ -1,0 +1,14 @@
+//go:build wasm
+
+package ffimetric
+
+import (
+	"unsafe"
+)
+
+//go:wasmimport env github.com/egdaemon/eg/runtime/wasi/runtime/metrics.Record
+func record(
+	deadline int64, // context.Context
+	nameptr unsafe.Pointer, namelen uint32, // metric name
+	payload unsafe.Pointer, payloadlen uint32, // json payload
+) uint32

--- a/runtime/wasi/internal/ffimetric/ffimetric.go
+++ b/runtime/wasi/internal/ffimetric/ffimetric.go
@@ -1,0 +1,25 @@
+package ffimetric
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/egdaemon/eg/internal/errorsx"
+	"github.com/egdaemon/eg/interp/runtime/wasi/ffiguest"
+)
+
+func Record(ctx context.Context, name string, payload any) (err error) {
+	var (
+		encoded []byte
+	)
+
+	if encoded, err = json.Marshal(payload); err != nil {
+		return errorsx.Wrap(err, "unable to marshal payload")
+	}
+
+	nameoffset, namelen := ffiguest.String(name)
+	payloadoffset, payloadlen := ffiguest.Bytes(encoded)
+
+	return ffiguest.Error(record(ffiguest.ContextDeadline(ctx), nameoffset, namelen, payloadoffset, payloadlen), fmt.Errorf("unable to record metric"))
+}


### PR DESCRIPTION
initial implementation to support recording custom metrics from the runtime, this is a per-requisite to supporting ML training for models.