### PR TITLE
fix container build permissions

### DIFF
--- a/.dist/archlinux/Containerfile
+++ b/.dist/archlinux/Containerfile
@@ -13,12 +13,12 @@ RUN pacman --noconfirm -Syu git cmake python-setuptools pybind11 python-numpy py
 # duckdb runtime time dependencies.
 RUN pacman --noconfirm -Syu gcc-libs openssl
 
+RUN chown -R egd:egd /tmp/pacman/
+
 # these commands are run manually with -C /tmp/pacman replaced with the rootfs pah.
 RUN sudo -H -S -u egd -g egd git -C /tmp/pacman clone https://aur.archlinux.org/yay.git
 RUN sudo -H -S -u egd -g egd git -C /tmp/pacman clone --depth 1 https://aur.archlinux.org/bindfs.git
 # RUN sudo -H -S -u egd git -C .dist/archlinux/rootfs/tmp/pacman clone --depth 1 https://aur.archlinux.org/duckdb.git # upstream is broken.
-
-RUN chown -R egd:egd /tmp/pacman/
 
 RUN ls -d /tmp/pacman/*/ | xargs -I {} sudo -H -P -E -S -u egd -g egd makepkg -D {} -Cs
 

--- a/.dist/archlinux/PKGBUILD
+++ b/.dist/archlinux/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=eg
-pkgver=v0.0.1737773138
+pkgver=v0.0.1737820545
 pkgrel=1
 pkgdesc='eg ci/cd/batch processing tooling'
 arch=('x86_64')


### PR DESCRIPTION
bootstrapping package directories need to be owned by egd.