### PR TITLE
add -modcacherw and -mod=readonly to compile options.

### DIFF
--- a/compile/compile.go
+++ b/compile/compile.go
@@ -104,7 +104,7 @@ func Run(ctx context.Context, dir, module string, output string) (err error) {
 	debugx.Println("compiling initiated", dir, module, "->", output)
 	defer debugx.Println("compiling completed", dir, module, "->", output)
 
-	cmd := exec.CommandContext(ctx, "go", "build", "-trimpath", "-o", output, strings.TrimPrefix(module, dir+"/"))
+	cmd := exec.CommandContext(ctx, "go", "build", "-mod=readonly", "-modcacherw", "-trimpath", "-o", output, strings.TrimPrefix(module, dir+"/"))
 	cmd.Env = append(os.Environ(), "GOOS=wasip1", "GOARCH=wasm")
 	cmd.Dir = dir
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
- dont want to deal with the dumb permissions caused by read only cache.
- want modules to be based off the go.mod vs vendor directory.