### PR TITLE
fix lintian issues and comment out debugging statement

### DIFF
--- a/.dist/linux/usr/share/bash-completion/completions/eg-daemon.sh
+++ b/.dist/linux/usr/share/bash-completion/completions/eg-daemon.sh
@@ -1,3 +1,1 @@
-#!/bin/bash
-
 eval "$(eg install-completions)"

--- a/.eg/debuild/eg/.debskel/debian/install
+++ b/.eg/debuild/eg/.debskel/debian/install
@@ -1,4 +1,0 @@
-src/.dist/linux/* /
-linux/* /
-
-

--- a/.eg/debuild/eg/.debskel/debian/rules
+++ b/.eg/debuild/eg/.debskel/debian/rules
@@ -22,7 +22,7 @@ override_dh_auto_build:
 	cp -R $(CURDIR)/src/.dist/linux/* $(CURDIR)/linux
 	# need to set gocache otherwise it'll error out on launchpad builders
 	GOPROXY="direct" GOCACHE="$(CURDIR)/.gocache" GOMODCACHE="$(CURDIR)/.gomod" GOBIN="$(CURDIR)/linux/usr/bin" /usr/lib/go-1.23/bin/go build -C src -mod=vendor -ldflags="-X 'github.com/egdaemon/eg/cmd/cmdopts.Treeish=${VCS_REVISION}'" -tags "no_duckdb_arrow" -buildmode=pie -buildvcs=false -o "$(CURDIR)/linux/usr/bin" ./cmd/...
-	tree $(CURDIR)/linux
+	# tree $(CURDIR)/linux
 
 override_dh_auto_test:
 	echo "DH AUTO TEST OVERRIDE"


### PR DESCRIPTION
- removes shebang from completions, not necessary and triggered lintian warning.
- commented out debugging statement that causes issues on launchpad build farm.
- removes debian install script in favor of the default one built into egdebuild module.