### PR TITLE
update genieql installation script and fix egdebuild.

### DIFF
--- a/.eg/debuild/egbootstrap/rootfs/usr/share/eg/install/genieql.sh
+++ b/.eg/debuild/egbootstrap/rootfs/usr/share/eg/install/genieql.sh
@@ -8,5 +8,5 @@ export GOMODCACHE=/tmp/gomodcache
 export GOCACHE=/tmp/gocache
 export GOBIN=/usr/local/bin
 
-git clone --single-branch -b concurrent-compilation https://bitbucket.org/jatone/genieql.git && go install -C genieql ./cmd/...
+git clone --single-branch -b main https://github.com/james-lawrence/genieql.git && go install -C genieql ./cmd/...
 rm -rf genieql

--- a/runtime/x/wasi/egdebuild/.debian/Containerfile
+++ b/runtime/x/wasi/egdebuild/.debian/Containerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:oracular
 ARG DEBIAN_FRONTEND=noninteractive
 
+RUN echo "cache buster 059a9a06-1686-4f49-9a7f-a30535886d68"
 RUN apt-get update
 RUN apt-get install -y software-properties-common build-essential ca-certificates curl sudo podman netavark rsync vim dput devscripts dh-make dput git uidmap dbus-user-session tree python3 python3.12-venv
 RUN add-apt-repository -n ppa:longsleep/golang-backports
@@ -8,7 +9,7 @@ RUN add-apt-repository -n ppa:egdaemon/eg
 RUN add-apt-repository -n ppa:egdaemon/duckdb
 
 RUN apt-get update
-RUN apt-get -y install golang-1.23 eg
+RUN apt-get -y install golang-1.24 eg egbootstrap
 
 RUN ln -s /usr/lib/go-1.23/bin/go /usr/local/bin/go
 

--- a/runtime/x/wasi/egdebuild/egdebuild.go
+++ b/runtime/x/wasi/egdebuild/egdebuild.go
@@ -237,9 +237,9 @@ func Build(cfg Config, opts ...option) eg.OpFn {
 			ctx,
 			runtime.Newf("chown -R egd:egd %s", root).Privileged(),
 			runtime.Newf("rsync --recursive --perms %s/ src/", cfg.SourceDir),
-			runtime.New("cat debian/changelog | envsubst | tee debian/changelog"),
-			runtime.New("cat debian/control | envsubst | tee debian/control"),
-			runtime.New("cat debian/rules | envsubst | tee debian/rules"),
+			runtime.New("cat debian/control | envsubst | tee debian/control.new && mv debian/control.new debian/control"),
+			runtime.New("cat debian/changelog | envsubst | tee debian/changelog.new && mv debian/changelog.new debian/changelog"),
+			runtime.New("cat debian/rules | envsubst | tee debian/rules.new && mv debian/rules.new debian/rules"),
 			cfg.buildCommand(&cfg, runtime),
 		)
 	}


### PR DESCRIPTION
egdebuild was overwriting the template files if the default debian files were used before they were read and translated.