### PR TITLE
fix egdmg option setters and applications symlink placement

### DIFF
--- a/runtime/x/wasi/egdmg/egdmg.go
+++ b/runtime/x/wasi/egdmg/egdmg.go
@@ -32,7 +32,7 @@ func OptionBuildDir(s string) Option {
 // directory to place dmg, defaults to egenv.WorkloadDirectory
 func OptionOutputDir(s string) Option {
 	return func(d *Specification) {
-		d.builddir = s
+		d.outputpath = s
 	}
 }
 
@@ -40,7 +40,7 @@ func OptionOutputDir(s string) Option {
 // defaults to {name}.dmg
 func OptionOutputName(s string) Option {
 	return func(d *Specification) {
-		d.builddir = s
+		d.outputname = s
 	}
 }
 
@@ -89,7 +89,7 @@ func Build(b Specification, archive string) eg.OpFn {
 		return shell.Run(
 			ctx,
 			sruntime.Newf("cp -R %s/ %s/", archive, filepath.Join(b.builddir, root)),
-			sruntime.Newf("ln -fs /Applications %s", filepath.Join(b.builddir, "Applications")),
+			sruntime.Newf("ln -fs /Applications %s", filepath.Join(b.builddir, root, "Applications")),
 			sruntime.New(cmd),
 		)
 	}

--- a/runtime/x/wasi/egdmg/egdmg_test.go
+++ b/runtime/x/wasi/egdmg/egdmg_test.go
@@ -3,6 +3,7 @@ package egdmg_test
 import (
 	"fmt"
 	"log"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -63,5 +64,52 @@ func TestBuild(t *testing.T) {
 
 			return true
 		}(r.Results()...), r.Results())
+	})
+
+	t.Run("applications symlink inside srcfolder", func(t *testing.T) {
+		tmpdir := testx.PrivateTemp(t)
+		r := &shell.Recorder{}
+		rt := shell.Runtime().UnsafeExec(r.Record).As("egd")
+
+		b := egdmg.New("eg", egdmg.OptionRuntime(rt), egdmg.OptionMkisofs)
+		require.NoError(t, egdmg.Build(b, testx.Fixture("example1"))(t.Context(), egtest.Op()))
+
+		cmds := r.Results()
+		require.Len(t, cmds, 3)
+		require.Contains(t, cmds[1], filepath.Join(tmpdir, "eg.app", "Applications"))
+	})
+
+	t.Run("option output dir sets outputpath", func(t *testing.T) {
+		tmpdir := testx.PrivateTemp(t)
+		r := &shell.Recorder{}
+		rt := shell.Runtime().UnsafeExec(r.Record).As("egd")
+
+		b := egdmg.New("eg", egdmg.OptionRuntime(rt), egdmg.OptionMkisofs, egdmg.OptionOutputDir("/custom/output"))
+		require.NoError(t, egdmg.Build(b, testx.Fixture("example1"))(t.Context(), egtest.Op()))
+
+		cmds := r.Results()
+		require.Len(t, cmds, 3)
+		// cp and symlink should still use the default builddir, not the output dir
+		require.Contains(t, cmds[0], filepath.Join(tmpdir, "eg.app"))
+		// mkisofs output should use the custom output dir
+		require.Contains(t, cmds[2], filepath.Join("/custom/output", "eg.dmg"))
+	})
+
+	t.Run("option output name sets outputname", func(t *testing.T) {
+		tmpdir := testx.PrivateTemp(t)
+		r := &shell.Recorder{}
+		rt := shell.Runtime().UnsafeExec(r.Record).As("egd")
+
+		b := egdmg.New("eg", egdmg.OptionRuntime(rt), egdmg.OptionMkisofs, egdmg.OptionOutputName("custom.dmg"))
+		require.NoError(t, egdmg.Build(b, testx.Fixture("example1"))(t.Context(), egtest.Op()))
+
+		cmds := r.Results()
+		require.Len(t, cmds, 3)
+		// cp and symlink should still use the default builddir
+		require.Contains(t, cmds[0], filepath.Join(tmpdir, "eg.app"))
+		// mkisofs output should use the custom name
+		require.Contains(t, cmds[2], "custom.dmg")
+		// mkisofs output should not use the default name
+		require.NotContains(t, cmds[2], "eg.dmg")
 	})
 }


### PR DESCRIPTION
OptionOutputDir and OptionOutputName both incorrectly set builddir instead of their respective fields, causing the build directory to be overwritten and DMG output to land in the wrong location.

The Applications symlink was placed at the builddir root instead of inside the srcfolder, so it never appeared in the resulting DMG.