### PR TITLE
remove .app suffix from dmg staging directory

### DIFF
--- a/runtime/x/wasi/egdmg/egdmg.go
+++ b/runtime/x/wasi/egdmg/egdmg.go
@@ -80,16 +80,15 @@ type Specification struct {
 
 func Build(b Specification, archive string) eg.OpFn {
 	return func(ctx context.Context, o eg.Op) error {
-		root := fmt.Sprintf("%s.app", b.name)
-		cmd := strings.ReplaceAll(b.cmd, "%dmg.volume.name%", root)
+		cmd := strings.ReplaceAll(b.cmd, "%dmg.volume.name%", b.name)
 		cmd = strings.ReplaceAll(cmd, "%dmg.volume.output%", filepath.Join(b.outputpath, b.outputname))
-		cmd = strings.ReplaceAll(cmd, "%dmg.src.directory%", filepath.Join(b.builddir, root))
+		cmd = strings.ReplaceAll(cmd, "%dmg.src.directory%", filepath.Join(b.builddir, b.name))
 
 		sruntime := b.runtime
 		return shell.Run(
 			ctx,
-			sruntime.Newf("cp -R %s/ %s/", archive, filepath.Join(b.builddir, root)),
-			sruntime.Newf("ln -fs /Applications %s", filepath.Join(b.builddir, root, "Applications")),
+			sruntime.Newf("cp -R %s/ %s/", archive, filepath.Join(b.builddir, b.name)),
+			sruntime.Newf("ln -fs /Applications %s", filepath.Join(b.builddir, b.name, "Applications")),
 			sruntime.New(cmd),
 		)
 	}

--- a/runtime/x/wasi/egdmg/egdmg.go
+++ b/runtime/x/wasi/egdmg/egdmg.go
@@ -3,6 +3,7 @@ package egdmg
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -85,13 +86,34 @@ func Build(b Specification, archive string) eg.OpFn {
 		cmd = strings.ReplaceAll(cmd, "%dmg.src.directory%", filepath.Join(b.builddir, b.name))
 
 		sruntime := b.runtime
-		return shell.Run(
+		if err := shell.Run(
 			ctx,
 			sruntime.Newf("cp -R %s/ %s/", archive, filepath.Join(b.builddir, b.name)),
 			sruntime.Newf("ln -fs /Applications %s", filepath.Join(b.builddir, b.name, "Applications")),
-			sruntime.New(cmd),
-		)
+		); err != nil {
+			return err
+		}
+
+		if err := templateInfoPlist(filepath.Join(b.builddir, b.name, "Contents", "Info.plist")); err != nil {
+			return err
+		}
+
+		return shell.Run(ctx, sruntime.New(cmd))
 	}
+}
+
+// templateInfoPlist replaces template variables in the Info.plist after copying.
+func templateInfoPlist(path string) error {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	templated := strings.ReplaceAll(string(data), "${DMG_BUNDLE_SIGNATURE}", "????")
+	return os.WriteFile(path, []byte(templated), 0644)
 }
 
 func root(paths ...string) string {

--- a/runtime/x/wasi/egdmg/egdmg_test.go
+++ b/runtime/x/wasi/egdmg/egdmg_test.go
@@ -31,12 +31,12 @@ func TestBuild(t *testing.T) {
 		// fsx.PrintFS(os.DirFS(egenv.EphemeralDirectory()))
 
 		// TODO:
-		// require.NoError(t, fsx.DirExists(egenv.EphemeralDirectory("eg.app")))
-		// require.Equal(t, testx.ReadMD5(testx.Fixture("example1", "hello.world.txt")), testx.ReadMD5(egenv.EphemeralDirectory("eg.app", "hello.world.txt")))
-		// require.Equal(t, testx.ReadMD5(testx.Fixture("example1", "Contents", "MacOS", "bin")), testx.ReadMD5(egenv.EphemeralDirectory("eg.app", "Contents", "MacOS", "bin")))
-		// require.Equal(t, testx.ReadMD5(testx.Fixture("example1", "Contents", "Resources", "icon.icns")), testx.ReadMD5(egenv.EphemeralDirectory("eg.app", "Contents", "Resources", "icon.icns")))
-		// require.NotEqual(t, testx.ReadMD5(testx.Fixture("example1", "Contents", "Info.plist")), testx.ReadMD5(egenv.EphemeralDirectory("eg.app", "Contents", "Info.plist")), testx.ReadString(egenv.EphemeralDirectory("eg.app", "Contents", "Info.plist")))
-		// require.Equal(t, "930df5f0-b121-133a-8d2a-51ed2a420683", testx.ReadMD5(egenv.EphemeralDirectory("eg.app", "Contents", "Info.plist")), testx.ReadString(egenv.EphemeralDirectory("eg.app", "Contents", "Info.plist")))
+		// require.NoError(t, fsx.DirExists(egenv.EphemeralDirectory("eg")))
+		// require.Equal(t, testx.ReadMD5(testx.Fixture("example1", "hello.world.txt")), testx.ReadMD5(egenv.EphemeralDirectory("eg", "hello.world.txt")))
+		// require.Equal(t, testx.ReadMD5(testx.Fixture("example1", "Contents", "MacOS", "bin")), testx.ReadMD5(egenv.EphemeralDirectory("eg", "Contents", "MacOS", "bin")))
+		// require.Equal(t, testx.ReadMD5(testx.Fixture("example1", "Contents", "Resources", "icon.icns")), testx.ReadMD5(egenv.EphemeralDirectory("eg", "Contents", "Resources", "icon.icns")))
+		// require.NotEqual(t, testx.ReadMD5(testx.Fixture("example1", "Contents", "Info.plist")), testx.ReadMD5(egenv.EphemeralDirectory("eg", "Contents", "Info.plist")), testx.ReadString(egenv.EphemeralDirectory("eg", "Contents", "Info.plist")))
+		// require.Equal(t, "930df5f0-b121-133a-8d2a-51ed2a420683", testx.ReadMD5(egenv.EphemeralDirectory("eg", "Contents", "Info.plist")), testx.ReadString(egenv.EphemeralDirectory("eg", "Contents", "Info.plist")))
 		require.True(t, func(cmds ...string) bool {
 			check := func(cmd, expected string) bool {
 
@@ -44,9 +44,9 @@ func TestBuild(t *testing.T) {
 			}
 
 			seq := []string{
-				fmt.Sprintf("::sudo:-E -H -u egd -g egd bash -c cp -R %s/ %s/eg.app/ ", testx.Fixture("example1"), tmpdir),
+				fmt.Sprintf("::sudo:-E -H -u egd -g egd bash -c cp -R %s/ %s/eg/ ", testx.Fixture("example1"), tmpdir),
 				"::sudo:-E -H -u egd -g egd bash -c ln -fs /Applications ",
-				"::sudo:-E -H -u egd -g egd bash -c mkisofs -D -R -apple -no-pad -V eg.app -o /workload/.eg.workspace/eg.dmg ",
+				"::sudo:-E -H -u egd -g egd bash -c mkisofs -D -R -apple -no-pad -V eg -o /workload/.eg.workspace/eg.dmg ",
 			}
 			if len(cmds) != len(seq) {
 				log.Println("invalid number of commands", len(cmds), "vs", len(seq))
@@ -76,7 +76,7 @@ func TestBuild(t *testing.T) {
 
 		cmds := r.Results()
 		require.Len(t, cmds, 3)
-		require.Contains(t, cmds[1], filepath.Join(tmpdir, "eg.app", "Applications"))
+		require.Contains(t, cmds[1], filepath.Join(tmpdir, "eg", "Applications"))
 	})
 
 	t.Run("option output dir sets outputpath", func(t *testing.T) {
@@ -90,7 +90,7 @@ func TestBuild(t *testing.T) {
 		cmds := r.Results()
 		require.Len(t, cmds, 3)
 		// cp and symlink should still use the default builddir, not the output dir
-		require.Contains(t, cmds[0], filepath.Join(tmpdir, "eg.app"))
+		require.Contains(t, cmds[0], filepath.Join(tmpdir, "eg"))
 		// mkisofs output should use the custom output dir
 		require.Contains(t, cmds[2], filepath.Join("/custom/output", "eg.dmg"))
 	})
@@ -106,7 +106,7 @@ func TestBuild(t *testing.T) {
 		cmds := r.Results()
 		require.Len(t, cmds, 3)
 		// cp and symlink should still use the default builddir
-		require.Contains(t, cmds[0], filepath.Join(tmpdir, "eg.app"))
+		require.Contains(t, cmds[0], filepath.Join(tmpdir, "eg"))
 		// mkisofs output should use the custom name
 		require.Contains(t, cmds[2], "custom.dmg")
 		// mkisofs output should not use the default name

--- a/runtime/x/wasi/egdmg/egdmg_test.go
+++ b/runtime/x/wasi/egdmg/egdmg_test.go
@@ -28,15 +28,6 @@ func TestBuild(t *testing.T) {
 
 		require.NoError(t, egdmg.Build(b, testx.Fixture("example1"))(t.Context(), egtest.Op()))
 
-		// fsx.PrintFS(os.DirFS(egenv.EphemeralDirectory()))
-
-		// TODO:
-		// require.NoError(t, fsx.DirExists(egenv.EphemeralDirectory("eg")))
-		// require.Equal(t, testx.ReadMD5(testx.Fixture("example1", "hello.world.txt")), testx.ReadMD5(egenv.EphemeralDirectory("eg", "hello.world.txt")))
-		// require.Equal(t, testx.ReadMD5(testx.Fixture("example1", "Contents", "MacOS", "bin")), testx.ReadMD5(egenv.EphemeralDirectory("eg", "Contents", "MacOS", "bin")))
-		// require.Equal(t, testx.ReadMD5(testx.Fixture("example1", "Contents", "Resources", "icon.icns")), testx.ReadMD5(egenv.EphemeralDirectory("eg", "Contents", "Resources", "icon.icns")))
-		// require.NotEqual(t, testx.ReadMD5(testx.Fixture("example1", "Contents", "Info.plist")), testx.ReadMD5(egenv.EphemeralDirectory("eg", "Contents", "Info.plist")), testx.ReadString(egenv.EphemeralDirectory("eg", "Contents", "Info.plist")))
-		// require.Equal(t, "930df5f0-b121-133a-8d2a-51ed2a420683", testx.ReadMD5(egenv.EphemeralDirectory("eg", "Contents", "Info.plist")), testx.ReadString(egenv.EphemeralDirectory("eg", "Contents", "Info.plist")))
 		require.True(t, func(cmds ...string) bool {
 			check := func(cmd, expected string) bool {
 
@@ -64,6 +55,20 @@ func TestBuild(t *testing.T) {
 
 			return true
 		}(r.Results()...), r.Results())
+	})
+
+	t.Run("copies archive contents into staging directory", func(t *testing.T) {
+		tmpdir := testx.PrivateTemp(t)
+		b := egdmg.New("eg", egdmg.OptionRuntime(shell.NewLocal()), egdmg.OptionDmgCmd("true"))
+		require.NoError(t, egdmg.Build(b, testx.Fixture("example1"))(t.Context(), egtest.Op()))
+
+		require.NoError(t, fsx.DirExists(filepath.Join(tmpdir, "eg")))
+		require.Equal(t, testx.ReadMD5(testx.Fixture("example1", "hello.world.txt")), testx.ReadMD5(filepath.Join(tmpdir, "eg", "hello.world.txt")))
+		require.Equal(t, testx.ReadMD5(testx.Fixture("example1", "Contents", "MacOS", "bin")), testx.ReadMD5(filepath.Join(tmpdir, "eg", "Contents", "MacOS", "bin")))
+		require.Equal(t, testx.ReadMD5(testx.Fixture("example1", "Contents", "Resources", "icon.icns")), testx.ReadMD5(filepath.Join(tmpdir, "eg", "Contents", "Resources", "icon.icns")))
+		require.NotEqual(t, testx.ReadMD5(testx.Fixture("example1", "Contents", "Info.plist")), testx.ReadMD5(filepath.Join(tmpdir, "eg", "Contents", "Info.plist")), testx.ReadString(filepath.Join(tmpdir, "eg", "Contents", "Info.plist")))
+		require.Equal(t, "1cbafcbe-a85d-7a8f-5578-a1215753ff1f", testx.ReadMD5(filepath.Join(tmpdir, "eg", "Contents", "Info.plist")), testx.ReadString(filepath.Join(tmpdir, "eg", "Contents", "Info.plist")))
+		require.NoError(t, fsx.SymlinkExists(filepath.Join(tmpdir, "eg", "Applications")))
 	})
 
 	t.Run("applications symlink inside srcfolder", func(t *testing.T) {


### PR DESCRIPTION
The staging directory was named {name}.app which appeared in the DMG root as a misleading directory that looked like a broken app bundle. Users had to navigate inside it to find the actual .app. Without the suffix, the DMG root directly contains the app and Applications symlink.