### PR TITLE
dramatically reduce eg's container footprint

### DIFF
--- a/interp/c8sproxy/c8s.go
+++ b/interp/c8sproxy/c8s.go
@@ -69,7 +69,7 @@ func PodmanPull(ctx context.Context, name string, options ...string) (cmd *exec.
 
 func PodmanBuild(ctx context.Context, name string, dir string, definition string, options ...string) (cmd *exec.Cmd, err error) {
 	args := []string{
-		"build", "--stdin", "-t", name, "-f", definition,
+		"build", "--stdin", "--squash", "-t", name, "-f", definition,
 	}
 	args = append(args, options...)
 	args = append(args, dir)


### PR DESCRIPTION
enable --squash flag to dramatically reduce overall eg footprint.