### PR TITLE
setup egnet for p2p bootstrapping.

### DIFF
--- a/.dist/linux/usr/lib/systemd/system/eg-runner-build.service
+++ b/.dist/linux/usr/lib/systemd/system/eg-runner-build.service
@@ -16,6 +16,7 @@ RuntimeDirectory=%p
 RuntimeDirectoryMode=0700
 Environment=EG_RUNNER_OVERRIDE_DIR=rootfs
 EnvironmentFile=-/etc/eg/runner.env
+ExecStartPre=/usr/bin/podman network create --ignore --ipv6 egnet
 ExecStart=/usr/bin/podman build --build-arg EG_RUNNER_OVERRIDE_DIR="${EG_RUNNER_OVERRIDE_DIR}" -t eg.runner -f /usr/share/eg/Containerfile /usr/share/eg
 # clear out the worklod cache after a successful rebuild.
 ExecStartPost=/usr/bin/rm -rf /var/cache/eg-runner/wcache

--- a/.dist/linux/usr/lib/systemd/system/eg-runner-gpu.service
+++ b/.dist/linux/usr/lib/systemd/system/eg-runner-gpu.service
@@ -7,8 +7,9 @@ Requires=eg-runner-build.service
 ProtectKernelModules=yes
 PrivateMounts=yes
 # interfers with ip v6 support. narrow to just the 169.254.x.x range
-# will need to add the aws metadata ipv6 address at some point.
 IPAddressDeny=169.254.0.0/16
+# aws metadata ipv6 address (IMDS); gcp/azure metadata is ipv4-only, no equivalent needed
+IPAddressDeny=fd00:ec2::254/128
 #IPAddressDeny=link-local
 #IPAddressDeny=multicast
 Restart=on-failure
@@ -22,7 +23,7 @@ Environment=EG_RUNNER_OVERRIDE_DIR=rootfs
 Environment=EG_RUNNER_DAEMON_ENV=/etc/eg/daemon.env
 EnvironmentFile=-/etc/eg/runner.env
 ExecStartPre=/usr/bin/echo ${EG_RUNNER_DAEMON_ENV} --cpus ${EG_RUNNER_CPU} --memory ${EG_RUNNER_MEMORY}
-ExecStart=/usr/bin/podman run --replace --name eg-runner --privileged --gpus=all --cap-add=sys_admin,mknod --security-opt label=disable --device /dev/fuse --pids-limit=-1 --hostname eg-runner-%m --volume /etc/eg/daemon.env:/etc/eg/daemon.env:ro --volume /etc/cdi:/etc/cdi:ro --volume %C/%p:/var/cache/eg-daemon:rw --attach STDERR --no-healthcheck --cpus ${EG_RUNNER_CPU} --memory ${EG_RUNNER_MEMORY} --userns host eg.runner:latest /sbin/init
+ExecStart=/usr/bin/podman run --replace --name eg-runner --network egnet --privileged --gpus=all --cap-add=sys_admin,mknod --security-opt label=disable --device /dev/fuse --pids-limit=-1 --hostname eg-runner-%m --volume /etc/eg/daemon.env:/etc/eg/daemon.env:ro --volume /etc/cdi:/etc/cdi:ro --volume %C/%p:/var/cache/eg-daemon:rw --attach STDERR --no-healthcheck --cpus ${EG_RUNNER_CPU} --memory ${EG_RUNNER_MEMORY} --userns host eg.runner:latest /sbin/init
 ExecStop=/usr/bin/podman stop eg
 
 [Install]

--- a/.dist/linux/usr/lib/systemd/system/eg-runner.service
+++ b/.dist/linux/usr/lib/systemd/system/eg-runner.service
@@ -7,8 +7,9 @@ Requires=eg-runner-build.service
 ProtectKernelModules=yes
 PrivateMounts=yes
 # interfers with ip v6 support. narrow to just the 169.254.x.x range
-# will need to add the aws metadata ipv6 address at some point.
 IPAddressDeny=169.254.0.0/16
+# aws metadata ipv6 address (IMDS); gcp/azure metadata is ipv4-only, no equivalent needed
+IPAddressDeny=fd00:ec2::254/128
 #IPAddressDeny=link-local
 #IPAddressDeny=multicast
 Restart=on-failure
@@ -22,7 +23,7 @@ Environment=EG_RUNNER_OVERRIDE_DIR=rootfs
 Environment=EG_RUNNER_DAEMON_ENV=/etc/eg/daemon.env
 EnvironmentFile=-/etc/eg/runner.env
 ExecStartPre=/usr/bin/echo ${EG_RUNNER_DAEMON_ENV} --cpus ${EG_RUNNER_CPU} --memory ${EG_RUNNER_MEMORY}
-ExecStart=/usr/bin/podman run --replace --name eg-runner --privileged --cap-add=sys_admin,mknod --security-opt label=disable --device /dev/fuse --pids-limit=-1 --hostname eg-runner-%m --volume /etc/eg/daemon.env:/etc/eg/daemon.env:ro --volume %C/%p:/var/cache/eg-daemon:rw --attach STDERR --no-healthcheck --cpus ${EG_RUNNER_CPU} --memory ${EG_RUNNER_MEMORY} --userns host eg.runner:latest /sbin/init
+ExecStart=/usr/bin/podman run --replace --name eg-runner --network egnet --privileged --cap-add=sys_admin,mknod --security-opt label=disable --device /dev/fuse --pids-limit=-1 --hostname eg-runner-%m --volume /etc/eg/daemon.env:/etc/eg/daemon.env:ro --volume %C/%p:/var/cache/eg-daemon:rw --attach STDERR --no-healthcheck --cpus ${EG_RUNNER_CPU} --memory ${EG_RUNNER_MEMORY} --userns host eg.runner:latest /sbin/init
 ExecStop=/usr/bin/podman stop eg
 
 [Install]


### PR DESCRIPTION
as part of the move to push instead of pull and to reduce upstream orchestration work we need ipv6 working by default within eg-runners.

this enables ipv6.